### PR TITLE
Change accelerator argument if no GPU available

### DIFF
--- a/train.py
+++ b/train.py
@@ -121,7 +121,7 @@ def get_trainer(gpus,params):
     trainer = pl.Trainer(devices=gpus, max_epochs=max_epochs,
                          gradient_clip_val=params['model']['gradient_clip_val'],
                          gradient_clip_algorithm=params['model']['gradient_clip_algorithm'],
-                         accelerator="gpu",
+                         accelerator="gpu" if gpus is not None else None,
                          callbacks=callback_funcs,logger=tb_logger,
                          profiler='simple',precision=params['experiment']['precision'],
                          strategy="ddp"


### PR DESCRIPTION
In `pl.Trainer`, `accelerator` should be `None` if no GPU(s) are available. Otherwise, it will rise `pytorch_lightning.utilities.exceptions.MisconfigurationException: No supported gpu backend found!`.